### PR TITLE
Supported `opa eval --coverage ... | ocov` in addition to `opa test ... --coverage | ocov`.

### DIFF
--- a/ocov.cc
+++ b/ocov.cc
@@ -81,19 +81,24 @@ int main(int argc, char** argv) {
   }
 
   try {
-    OPATestInput const ocov = [&]() {
-      std::string const input = ReadInput();
-      auto as_test_input = TryParseJSON<OPATestInput, JSONFormat::Minimalistic>(input);
-      if (Exists(as_test_input)) {
-        return Value(as_test_input);
-      }
+    std::string const input = ReadInput();
+    OPATestInput ocov;
+    std::string test_or_eval;
+    auto as_test_input = TryParseJSON<OPATestInput, JSONFormat::Minimalistic>(input);
+    if (Exists(as_test_input)) {
+      test_or_eval = "test";
+      ocov = std::move(Value(as_test_input));
+    } else {
       auto as_eval_input = TryParseJSON<OPAEvalInput, JSONFormat::Minimalistic>(input);
       if (Exists(as_eval_input)) {
-        return Value(as_eval_input).coverage;
+        test_or_eval = "eval";
+        ocov = std::move(Value(as_eval_input).coverage);
       }
+    }
+    if (test_or_eval.empty()) {
       std::cerr << red << bold << "The input should be from `opa test` or from `opa eval`." << reset << std::endl;
       std::exit(1);
-    }();
+    }
     bool first = true;
     for (auto const& file : ocov.files) {
       if (!first) {
@@ -103,8 +108,8 @@ int main(int argc, char** argv) {
       }
       std::cout << bold << "# " << blue << file.first << reset << std::endl;
       if (Exists(file.second.coverage)) {
-        std::cout << bold << "# " << yellow << "file test coverage: " << Value(file.second.coverage) << '%' << reset
-                  << std::endl;
+        std::cout << bold << "# " << yellow << "file " << test_or_eval
+                  << " coverage: " << Value(file.second.coverage) << '%' << reset << std::endl;
       }
       try {
         std::string const filename = current::FileSystem::JoinPath(FLAGS_basedir, file.first);
@@ -163,8 +168,8 @@ int main(int argc, char** argv) {
     }
     if (Exists(ocov.coverage)) {
       std::cout << std::endl
-                << bold << "# " << yellow << "total test coverage: " << Value(ocov.coverage) << '%' << reset
-                << std::endl;
+                << bold << "# " << yellow << "total " << test_or_eval
+                << " coverage: " << Value(ocov.coverage) << '%' << reset << std::endl;
     }
     return 0;
   } catch (current::Exception const& e) {


### PR DESCRIPTION
I'll just merge this in, @mzhurovich -- per @anderseknert's request in https://github.com/C5T/ocov/issues/1.